### PR TITLE
job_hook: set URL for currently building PRs to PR overview

### DIFF
--- a/murdock.py
+++ b/murdock.py
@@ -308,6 +308,8 @@ class PullRequest(object):
                 }
         if target_url:
             status["target_url"] = target_url
+        else:
+            status["target_url"] = config.http_root
 
         s.set_status(arg, state, status)
 


### PR DESCRIPTION
Sets the URL for pending builds (but not the waiting for review ones introduced in #3 ;-)) to https://ci.riot-labs.de/.