### PR TITLE
job_hook: don't link to non-existing files

### DIFF
--- a/murdock.py
+++ b/murdock.py
@@ -294,6 +294,7 @@ class PullRequest(object):
                 description = "The build failed. runtime: %s" % nicetime(runtime)
             else:
                 state = "failure"
+                target_url = None
                 if job.result == JobResult.canceled:
                     description = "The build has been canceled."
                 else:


### PR DESCRIPTION
Canceled jobs or jobs with unknown errors most likely don't have an output file, so don't set the target_url to it. https://github.com/RIOT-OS/RIOT/pull/5573 is current example for that.