### PR TITLE
Add tornado as a dependency to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Developed for RIOT (riot-os.org).
 # Requirements
 
 - python3
+- Tornado python module
 - agithub python module (tested with v2.1 from pip)
 - pytoml python module
 


### PR DESCRIPTION
Murdock also depends on tornado, but this isn't listed in the requirements section of the README