### PR TITLE
github_webhook: prefer status.json over html snip

### DIFF
--- a/github_webhook.py
+++ b/github_webhook.py
@@ -90,6 +90,8 @@ class GithubWebhook(object):
                                                    "prstatus.json")
                     if os.path.isfile(status_jsonfile):
                         with open(status_jsonfile) as f:
+                            # Content is up for interpretation between backend
+                            # and frontend scripting
                             extras["status"] = json.load(f)
                     if "status" not in extras:
                         status_html_snipfile = os.path.join(


### PR DESCRIPTION
If a JSON file (see https://github.com/RIOT-OS/murdock-scripts/pull/18) instead of an HTML snippet is present, prefer that over it.

Requires https://github.com/RIOT-OS/murdock-html/pull/4 to render the JSON status properly in the RIOT set-up.