### PR TITLE
github_webhook: move tornado handler classes outside the main tornado application

### DIFF
--- a/github_webhook.py
+++ b/github_webhook.py
@@ -9,16 +9,157 @@ from threading import Lock
 
 config.set_default("url_prefix", r"")
 
+
+class PullRequestHandler(tornado.web.RequestHandler):
+    def initialize(self, prs):
+        self.prs = prs
+
+    def get(self):
+        def gen_pull_entry(pr, job, time, extra = None):
+            res = extra or {}
+            res.update({
+                    "title" : pr.title,
+                    "user" : pr.user,
+                    "url" : pr.url,
+                    "commit" : job.arg,
+                    "since" : time,
+                    })
+            return res
+
+        self.set_header("Content-Type", 'application/json; charset="utf-8"')
+        self.set_header("Access-Control-Allow-Credentials", "false")
+        self.set_header("Access-Control-Allow-Origin", "*")
+
+        building, queued, finished = self.prs.list()
+        response = {}
+
+        if building:
+            _building = []
+            for pr, job in building:
+                _building.append(
+                        gen_pull_entry(pr, job, job.time_started))
+            response['building'] = _building
+
+        if queued:
+            _queued = []
+            for pr, job in queued:
+                _queued.append(
+                        gen_pull_entry(pr, job, job.time_queued))
+
+            response['queued'] = _queued
+
+        if finished:
+            _finished = []
+            for pr, job in finished:
+                job_path_rel = os.path.join(pr.base_full_name, str(pr.nr), job.arg)
+                job_path_local = os.path.join(config.data_dir, job_path_rel)
+                job_path_url = os.path.join(config.http_root, job_path_rel)
+
+                extras = {
+                    "output_url": os.path.join(job_path_url, "output.html"),
+                    "result": job.result.name,
+                    "runtime": (job.time_finished - job.time_started),
+                  }
+                status_jsonfile = os.path.join(job_path_local,
+                                               "prstatus.json")
+                if os.path.isfile(status_jsonfile):
+                    with open(status_jsonfile) as f:
+                        # Content is up for interpretation between backend
+                        # and frontend scripting
+                        extras["status"] = json.load(f)
+                if "status" not in extras:
+                    status_html_snipfile = os.path.join(
+                            job_path_local, "prstatus.html.snip"
+                        )
+
+                    status_html = ""
+                    if os.path.isfile(status_html_snipfile):
+                        with open(status_html_snipfile, "r") as f:
+                            status_html = f.read()
+                    extras["status_html"] = status_html
+
+                _finished.append(
+                        gen_pull_entry(pr, job, job.time_finished, extras)
+                    )
+
+            response['finished'] = _finished
+
+        self.write(json.dumps(response, sort_keys=False, indent=4))
+
+
+class GithubWebhookHandler(tornado.web.RequestHandler):
+    def initialize(self, handler):
+        self.handler = handler
+
+    def post(self):
+        self.write("ok")
+        hook_type = self.request.headers.get('X-Github-Event')
+
+        handler = self.handler.get(hook_type)
+        if handler:
+            handler(self.request)
+        else:
+            log.warning("unhandled github event: %s", hook_type)
+
+
+class StatusWebSocket(tornado.websocket.WebSocketHandler):
+    lock = Lock()
+    websockets = set()
+    keeper = None
+
+    # passive read only websocket, so anyone can read
+    def check_origin(self, origin):
+        return True
+
+    @staticmethod
+    def write_message_all(message, binary=False):
+        s = StatusWebSocket
+        with s.lock:
+            for websocket in s.websockets:
+                websocket.write_message(message, binary)
+
+    @staticmethod
+    def keep_alive():
+        s = StatusWebSocket
+        with s.lock:
+            for websocket in s.websockets:
+                websocket.ping("ping".encode("ascii"))
+
+    def open(self):
+        print("websocket opened")
+        with self.lock:
+            if not self.websockets:
+                s = StatusWebSocket
+                s.keeper = tornado.ioloop.PeriodicCallback(s.keep_alive, 30*1000)
+                s.keeper.start()
+            self.websockets.add(self)
+
+    def on_message(self, message):
+        pass
+
+    def on_close(self):
+        with self.lock:
+            self.websockets.discard(self)
+            if not self.websockets:
+                self.keeper.stop()
+
+
+class ControlHandler(tornado.web.RequestHandler):
+    def post(self):
+#       data = json.loads(self.request.body)
+        s = StatusWebSocket
+        s.write_message_all(self.request.body)
+
+
 class GithubWebhook(tornado.web.Application):
-    
+
     def __init__(self, prs, github_handlers):
         self.secret = "__secret"
         handlers = [
-#            (r"/", GithubWebhook.MainHandler),
-            (config.url_prefix + r"/api/pull_requests", GithubWebhook.PullRequestHandler, dict(prs=prs)),
-            (config.url_prefix + r"/github", GithubWebhook.GithubWebhookHandler, dict(handler=github_handlers)),
-            (config.url_prefix + r"/status", GithubWebhook.StatusWebSocket),
-            (config.url_prefix + r"/control", GithubWebhook.ControlHandler),
+            (config.url_prefix + r"/api/pull_requests", PullRequestHandler, dict(prs=prs)),
+            (config.url_prefix + r"/github", GithubWebhookHandler, dict(handler=github_handlers)),
+            (config.url_prefix + r"/status", StatusWebSocket),
+            (config.url_prefix + r"/control", ControlHandler),
         ]
 
         self.websocket_lock = Lock()
@@ -26,144 +167,3 @@ class GithubWebhook(tornado.web.Application):
         settings = {'debug': True}
         super(GithubWebhook, self).__init__(handlers, **settings)
 
-
-    class MainHandler(tornado.web.RequestHandler):
-        def get(self):
-            self.write("...")
-
-    class PullRequestHandler(tornado.web.RequestHandler):
-        def initialize(self, prs):
-            self.prs = prs
-
-        def get(self):
-            def gen_pull_entry(pr, job, time, extra = None):
-                res = extra or {}
-                res.update({
-                        "title" : pr.title,
-                        "user" : pr.user,
-                        "url" : pr.url,
-                        "commit" : job.arg,
-                        "since" : time,
-                        })
-                return res
-
-            self.set_header("Content-Type", 'application/json; charset="utf-8"')
-            self.set_header("Access-Control-Allow-Credentials", "false")
-            self.set_header("Access-Control-Allow-Origin", "*")
-
-            building, queued, finished = self.prs.list()
-            response = {}
-
-            if building:
-                _building = []
-                for pr, job in building:
-                    _building.append(
-                            gen_pull_entry(pr, job, job.time_started))
-                response['building'] = _building
-
-            if queued:
-                _queued = []
-                for pr, job in queued:
-                    _queued.append(
-                            gen_pull_entry(pr, job, job.time_queued))
-
-                response['queued'] = _queued
-
-            if finished:
-                _finished = []
-                for pr, job in finished:
-                    job_path_rel = os.path.join(pr.base_full_name, str(pr.nr), job.arg)
-                    job_path_local = os.path.join(config.data_dir, job_path_rel)
-                    job_path_url = os.path.join(config.http_root, job_path_rel)
-
-                    extras = {
-                        "output_url": os.path.join(job_path_url, "output.html"),
-                        "result": job.result.name,
-                        "runtime": (job.time_finished - job.time_started),
-                      }
-                    status_jsonfile = os.path.join(job_path_local,
-                                                   "prstatus.json")
-                    if os.path.isfile(status_jsonfile):
-                        with open(status_jsonfile) as f:
-                            # Content is up for interpretation between backend
-                            # and frontend scripting
-                            extras["status"] = json.load(f)
-                    if "status" not in extras:
-                        status_html_snipfile = os.path.join(
-                                job_path_local, "prstatus.html.snip"
-                            )
-
-                        status_html = ""
-                        if os.path.isfile(status_html_snipfile):
-                            with open(status_html_snipfile, "r") as f:
-                                status_html = f.read()
-                        extras["status_html"] = status_html
-
-                    _finished.append(
-                            gen_pull_entry(pr, job, job.time_finished, extras)
-                        )
-
-                response['finished'] = _finished
-
-            self.write(json.dumps(response, sort_keys=False, indent=4))
-
-    class GithubWebhookHandler(tornado.web.RequestHandler):
-        def initialize(self, handler):
-            self.handler = handler
-
-        def post(self):
-            self.write("ok")
-            hook_type = self.request.headers.get('X-Github-Event')
-
-            handler = self.handler.get(hook_type)
-            if handler:
-                handler(self.request)
-            else:
-                log.warning("unhandled github event: %s", hook_type)
-
-    class StatusWebSocket(tornado.websocket.WebSocketHandler):
-        lock = Lock()
-        websockets = set()
-        keeper = None
-
-        # passive read only websocket, so anyone can read
-        def check_origin(self, origin):
-            return True
-
-        @staticmethod
-        def write_message_all(message, binary=False):
-            s = GithubWebhook.StatusWebSocket
-            with s.lock:
-                for websocket in s.websockets:
-                    websocket.write_message(message, binary)
-
-        @staticmethod
-        def keep_alive():
-            s = GithubWebhook.StatusWebSocket
-            with s.lock:
-                for websocket in s.websockets:
-                    websocket.ping("ping".encode("ascii"))
-
-        def open(self):
-            print("websocket opened")
-            with self.lock:
-                if not self.websockets:
-                    s = GithubWebhook.StatusWebSocket
-                    s.keeper = tornado.ioloop.PeriodicCallback(s.keep_alive, 30*1000)
-                    s.keeper.start()
-                self.websockets.add(self)
-
-        def on_message(self, message):
-            pass
-
-        def on_close(self):
-            with self.lock:
-                self.websockets.discard(self)
-                if not self.websockets:
-                    self.keeper.stop()
-
-    class ControlHandler(tornado.web.RequestHandler):
-        def post(self):
-#            data = json.loads(self.request.body)
-            s = GithubWebhook.StatusWebSocket
-            s.write_message_all(self.request.body)

--- a/github_webhook.py
+++ b/github_webhook.py
@@ -1,7 +1,4 @@
-import tornado.httpserver
-import tornado.ioloop
-import tornado.web
-import tornado.websocket
+import tornado
 import json
 import os
 

--- a/github_webhook.py
+++ b/github_webhook.py
@@ -10,7 +10,7 @@ from threading import Lock
 config.set_default("url_prefix", r"")
 
 class GithubWebhook(tornado.web.Application):
-
+    
     def __init__(self, prs, github_handlers):
         self.secret = "__secret"
         handlers = [
@@ -26,9 +26,6 @@ class GithubWebhook(tornado.web.Application):
         settings = {'debug': True}
         super(GithubWebhook, self).__init__(handlers, **settings)
 
-    def run(self):
-        log.info("tornado IOLoop started.")
-        tornado.ioloop.IOLoop.instance().start()
 
     class MainHandler(tornado.web.RequestHandler):
         def get(self):

--- a/jobs.py
+++ b/jobs.py
@@ -20,55 +20,57 @@ class JobResult(Enum):
 
 class Job(object):
     id = 0
-    def __init__(s, name, cmd, env=None, hook=None, arg=None):
-        s.lock = Lock()
-        s.id = Job.id
+    def __init__(self, name, cmd, env=None, hook=None, arg=None):
+        self.lock = Lock()
+        self.id = Job.id
         Job.id += 1
 
-        s.name = name
-        s.cmd = cmd
-        s.env = env
-        s.worker = None
+        self.name = name
+        self.cmd = cmd
+        self.env = env
+        self.worker = None
 
-        s.hook = hook
-        s.arg = arg
+        self.hook = hook
+        self.arg = arg
 
-        s.result = JobResult.unknown
+        self.result = JobResult.unknown
 
-        s.time_created = -1
-        s.time_queued = -1
-        s.time_started = -1
-        s.time_finished = -1
+        self.time_created = -1
+        self.time_queued = -1
+        self.time_started = -1
+        self.time_finished = -1
 
-        s.set_state(JobState.created)
+        self.set_state(JobState.created)
 
-    def data_dir(s):
-        return s.name #,os.path.join(config.data_dir, s.name + "." + str(s.id))
+    def data_dir(self):
+        return self.name #,os.path.join(config.data_dir, s.name + "." + str(s.id))
 
-    def set_state(s, state, result=JobResult.unknown):
-        with s.lock:
-            s.state = state
-            s.result = result
-            if s.state == JobState.created:
-                s.time_created = time.time()
-            elif s.state == JobState.queued:
-                s.time_queued = time.time()
-            elif s.state == JobState.running:
-                s.time_started = time.time()
-            elif s.state == JobState.finished:
-                s.time_finished = time.time()
+    def set_state(self, state, result=JobResult.unknown):
+        with self.lock:
+            self.state = state
+            self.result = result
+            if self.state == JobState.created:
+                self.time_created = time.time()
+            elif self.state == JobState.queued:
+                self.time_queued = time.time()
+            elif self.state == JobState.running:
+                self.time_started = time.time()
+            elif self.state == JobState.finished:
+                self.time_finished = time.time()
 
-            log.info("Job %s: new state: %s %s %s %s %s %s " , s.name, s.state, s.result, s.time_created, s.time_queued, s.time_started, s.time_finished)
+            log.info("Job %s: new state: %s %s %s %s %s %s " ,
+                     self.name, self.state, self.result, self.time_created,
+                     self.time_queued, self.time_started, self.time_finished)
 
-        if s.hook:
-            s.hook(s.arg, s)
+        if self.hook:
+            self.hook(self.arg, self)
 
-    def stopped(s, result):
-        with s.lock:
-            s.state = result
+    def stopped(self, result):
+        with self.lock:
+            self.state = result
 
-    def cancel(s):
-        if s.worker:
-            s.worker.cancel(s)
+    def cancel(self):
+        if self.worker:
+            self.worker.cancel(self)
         else:
-            s.set_state(JobState.finished, JobResult.canceled)
+            self.set_state(JobState.finished, JobResult.canceled)

--- a/murdock.py
+++ b/murdock.py
@@ -497,8 +497,10 @@ def main():
 
 #    threading.Thread(target=startup_load_pull_requests, daemon=True).start()
 
-    g = GithubWebhook(config.port, PullRequest, github_handlers)
-    g.run()
+    webhook = GithubWebhook(PullRequest, github_handlers)
+    webhook.listen(config.port)
+    log.info("Start tornado IOLoop")
+    tornado.ioloop.IOLoop.instance().start()
 
     # tornado loop ended
 

--- a/murdock.py
+++ b/murdock.py
@@ -16,7 +16,7 @@ import threading
 from queue import Queue, Empty
 
 from jobs import Job, JobResult, JobState
-from github_webhook import GithubWebhook
+from github_webhook import GithubWebhook, StatusWebSocket
 
 from util import config
 from threading import Lock
@@ -352,7 +352,7 @@ class PullRequest(object):
             log.info("PR %s runtime: %s", s.url, nicetime(runtime))
 
         log.info("PR %s notifying webhooks", s.url)
-        GithubWebhook.StatusWebSocket.write_message_all('{ "cmd" :"reload_prs" }')
+        StatusWebSocket.write_message_all('{ "cmd" :"reload_prs" }')
 
     def set_status(s, commit, **kwargs):
         status = {


### PR DESCRIPTION
There is no real benefit with this change but it makes things easier to read.
Nested classes are valid in Python but in general, it's better to use them when they are small. Here some handler contains a lot of logic (PullRequestHandler, StatusHandler).

based on #27, #26 and #25 